### PR TITLE
Add cart and checkout functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository contains a very simple static website for selling rubber ducks. Open `index.html` in a web browser to view the store locally.
 
-The page lists a few example products and includes a small JavaScript snippet to keep track of a pretend cart count. There is no backend or checkout functionality; this is purely a front-end mockup.
+The page lists a few example products and includes JavaScript to keep track of a pretend cart. A new checkout page (`checkout.html`) shows the chosen ducks and the total cost. There is still no backend; everything runs locally in the browser.

--- a/checkout.html
+++ b/checkout.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Checkout</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Checkout</h1>
+        <div class="cart">Cart: <span id="cart-count">0</span></div>
+        <a href="index.html" class="checkout-button">Continue Shopping</a>
+    </header>
+    <main>
+        <div id="cart-items"></div>
+        <div id="total" class="total"></div>
+        <button id="place-order">Place Order</button>
+    </main>
+    <script src="script.js"></script>
+    <script>
+        displayCart();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -11,25 +11,26 @@
     <header>
         <h1>Rubber Duck Store</h1>
         <div class="cart">Cart: <span id="cart-count">0</span></div>
+        <a href="checkout.html" class="checkout-button">Checkout</a>
     </header>
     <main>
         <div class="product">
             <img src="https://dummyimage.com/200x200/ffde00/000&text=Classic+Duck" alt="Classic Yellow Duck" />
             <h2>Classic Yellow Duck</h2>
             <p class="price">$5.00</p>
-            <button onclick="addToCart()">Add to Cart</button>
+            <button onclick="addToCart('Classic Yellow Duck', 5.00, 'https://dummyimage.com/200x200/ffde00/000&text=Classic+Duck')">Add to Cart</button>
         </div>
         <div class="product">
             <img src="https://dummyimage.com/200x200/00aaff/000&text=Fancy+Blue+Duck" alt="Fancy Blue Duck" />
             <h2>Fancy Blue Duck</h2>
             <p class="price">$7.50</p>
-            <button onclick="addToCart()">Add to Cart</button>
+            <button onclick="addToCart('Fancy Blue Duck', 7.50, 'https://dummyimage.com/200x200/00aaff/000&text=Fancy+Blue+Duck')">Add to Cart</button>
         </div>
         <div class="product">
             <img src="https://dummyimage.com/200x200/ff00aa/000&text=Giant+Duck" alt="Giant Duck" />
             <h2>Giant Duck</h2>
             <p class="price">$12.00</p>
-            <button onclick="addToCart()">Add to Cart</button>
+            <button onclick="addToCart('Giant Duck', 12.00, 'https://dummyimage.com/200x200/ff00aa/000&text=Giant+Duck')">Add to Cart</button>
         </div>
     </main>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,5 +1,43 @@
-let cartCount = 0;
-function addToCart() {
-    cartCount += 1;
-    document.getElementById('cart-count').textContent = cartCount;
+let cart = JSON.parse(localStorage.getItem('cart')) || [];
+updateCartCount();
+
+function addToCart(name, price, image) {
+    cart.push({ name, price, image });
+    localStorage.setItem('cart', JSON.stringify(cart));
+    updateCartCount();
 }
+
+function updateCartCount() {
+    document.getElementById('cart-count').textContent = cart.length;
+}
+
+function displayCart() {
+    updateCartCount();
+    const container = document.getElementById('cart-items');
+    if (!container) return;
+    container.innerHTML = '';
+    let total = 0;
+    cart.forEach(item => {
+        total += item.price;
+        const div = document.createElement('div');
+        div.className = 'cart-item';
+        div.innerHTML = `<img src="${item.image}" alt="${item.name}"> <span>${item.name}</span> - $${item.price.toFixed(2)}`;
+        container.appendChild(div);
+    });
+    const totalElem = document.getElementById('total');
+    if (totalElem) {
+        totalElem.textContent = `Total: $${total.toFixed(2)}`;
+    }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+    const placeOrderBtn = document.getElementById('place-order');
+    if (placeOrderBtn) {
+        placeOrderBtn.addEventListener('click', () => {
+            cart = [];
+            localStorage.removeItem('cart');
+            displayCart();
+            alert('Order placed!');
+        });
+    }
+});

--- a/style.css
+++ b/style.css
@@ -49,3 +49,27 @@ button {
 button:hover {
     background: #008ecc;
 }
+
+.checkout-button {
+    background: #00cc66;
+    color: #fff;
+    padding: 10px;
+    text-decoration: none;
+}
+
+.cart-item {
+    display: flex;
+    align-items: center;
+    margin-bottom: 10px;
+}
+
+.cart-item img {
+    width: 50px;
+    height: auto;
+    margin-right: 10px;
+}
+
+.total {
+    font-weight: bold;
+    margin-top: 20px;
+}


### PR DESCRIPTION
## Summary
- add checkout link on main page and product-specific `addToCart` calls
- implement persistent cart logic and checkout interactions in `script.js`
- style checkout elements and button
- create new `checkout.html` page to review selected ducks
- update README with checkout details

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6841a544d430832ebb48c4135345d62c