### PR TITLE
Add offline images and PayPal checkout

### DIFF
--- a/checkout.html
+++ b/checkout.html
@@ -6,6 +6,7 @@
     <title>Checkout</title>
     <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="style.css">
+    <script src="https://www.paypal.com/sdk/js?client-id=sb&currency=USD"></script>
 </head>
 <body>
     <header>
@@ -16,6 +17,7 @@
     <main>
         <div id="cart-items"></div>
         <div id="total" class="total"></div>
+        <div id="paypal-button-container"></div>
         <button id="place-order">Place Order</button>
     </main>
     <script src="script.js"></script>

--- a/index.html
+++ b/index.html
@@ -16,22 +16,22 @@
     </header>
     <main>
         <div class="product">
-            <img src="https://source.unsplash.com/200x200/?rubber-duck" alt="Classic Yellow Duck" />
+            <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSIxMjAiIHI9IjQwIiBmaWxsPSIjZmZlYjNiIi8+CiAgPGNpcmNsZSBjeD0iMTIwIiBjeT0iMTAwIiByPSIzMCIgZmlsbD0iI2ZmZWIzYiIvPgogIDxwYXRoIGQ9Ik0xNTAgMTAwIEwxNzAgOTAgTDE3MCAxMTAgWiIgZmlsbD0iI2ZmOTgwMCIvPgo8L3N2Zz4=" alt="Classic Yellow Duck" />
             <h2>Classic Yellow Duck</h2>
             <p class="price">$5.00</p>
-            <button onclick="addToCart('Classic Yellow Duck', 5.00, 'https://source.unsplash.com/200x200/?rubber-duck')">Add to Cart</button>
+            <button onclick="addToCart('Classic Yellow Duck', 5.00, 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSIxMjAiIHI9IjQwIiBmaWxsPSIjZmZlYjNiIi8+CiAgPGNpcmNsZSBjeD0iMTIwIiBjeT0iMTAwIiByPSIzMCIgZmlsbD0iI2ZmZWIzYiIvPgogIDxwYXRoIGQ9Ik0xNTAgMTAwIEwxNzAgOTAgTDE3MCAxMTAgWiIgZmlsbD0iI2ZmOTgwMCIvPgo8L3N2Zz4=')">Add to Cart</button>
         </div>
         <div class="product">
-            <img src="https://source.unsplash.com/200x200/?rubber-duck,blue" alt="Fancy Blue Duck" />
+            <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSIxMjAiIHI9IjQwIiBmaWxsPSIjMjE5NkYzIi8+CiAgPGNpcmNsZSBjeD0iMTIwIiBjeT0iMTAwIiByPSIzMCIgZmlsbD0iIzIxOTZGMyIvPgogIDxwYXRoIGQ9Ik0xNTAgMTAwIEwxNzAgOTAgTDE3MCAxMTAgWiIgZmlsbD0iI2ZmOTgwMCIvPgo8L3N2Zz4=" alt="Fancy Blue Duck" />
             <h2>Fancy Blue Duck</h2>
             <p class="price">$7.50</p>
-            <button onclick="addToCart('Fancy Blue Duck', 7.50, 'https://source.unsplash.com/200x200/?rubber-duck,blue')">Add to Cart</button>
+            <button onclick="addToCart('Fancy Blue Duck', 7.50, 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSIxMjAiIHI9IjQwIiBmaWxsPSIjMjE5NkYzIi8+CiAgPGNpcmNsZSBjeD0iMTIwIiBjeT0iMTAwIiByPSIzMCIgZmlsbD0iIzIxOTZGMyIvPgogIDxwYXRoIGQ9Ik0xNTAgMTAwIEwxNzAgOTAgTDE3MCAxMTAgWiIgZmlsbD0iI2ZmOTgwMCIvPgo8L3N2Zz4=')">Add to Cart</button>
         </div>
         <div class="product">
-            <img src="https://source.unsplash.com/200x200/?giant-duck" alt="Giant Duck" />
+            <img src="data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSIxMjAiIHI9IjUwIiBmaWxsPSIjZmZlYjNiIi8+CiAgPGNpcmNsZSBjeD0iMTMwIiBjeT0iMTAwIiByPSI0MCIgZmlsbD0iI2ZmZWIzYiIvPgogIDxwYXRoIGQ9Ik0xNzAgMTAwIEwxOTUgOTAgTDE5NSAxMTAgWiIgZmlsbD0iI2ZmOTgwMCIvPgo8L3N2Zz4=" alt="Giant Duck" />
             <h2>Giant Duck</h2>
             <p class="price">$12.00</p>
-            <button onclick="addToCart('Giant Duck', 12.00, 'https://source.unsplash.com/200x200/?giant-duck')">Add to Cart</button>
+            <button onclick="addToCart('Giant Duck', 12.00, 'data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHdpZHRoPSIyMDAiIGhlaWdodD0iMjAwIiB2aWV3Qm94PSIwIDAgMjAwIDIwMCI+CiAgPGNpcmNsZSBjeD0iODAiIGN5PSIxMjAiIHI9IjUwIiBmaWxsPSIjZmZlYjNiIi8+CiAgPGNpcmNsZSBjeD0iMTMwIiBjeT0iMTAwIiByPSI0MCIgZmlsbD0iI2ZmZWIzYiIvPgogIDxwYXRoIGQ9Ik0xNzAgMTAwIEwxOTUgOTAgTDE5NSAxMTAgWiIgZmlsbD0iI2ZmOTgwMCIvPgo8L3N2Zz4=')">Add to Cart</button>
         </div>
     </main>
     <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,5 @@
 let cart = JSON.parse(localStorage.getItem('cart')) || [];
+let cartTotal = 0;
 updateCartCount();
 
 function addToCart(name, price, image) {
@@ -16,9 +17,9 @@ function displayCart() {
     const container = document.getElementById('cart-items');
     if (!container) return;
     container.innerHTML = '';
-    let total = 0;
+    cartTotal = 0;
     cart.forEach(item => {
-        total += item.price;
+        cartTotal += item.price;
         const div = document.createElement('div');
         div.className = 'cart-item';
         div.innerHTML = `<img src="${item.image}" alt="${item.name}"> <span>${item.name}</span> - $${item.price.toFixed(2)}`;
@@ -26,8 +27,30 @@ function displayCart() {
     });
     const totalElem = document.getElementById('total');
     if (totalElem) {
-        totalElem.textContent = `Total: $${total.toFixed(2)}`;
+        totalElem.textContent = `Total: $${cartTotal.toFixed(2)}`;
     }
+    renderPayPalButton();
+}
+
+function renderPayPalButton() {
+    const container = document.getElementById('paypal-button-container');
+    if (!container || typeof paypal === 'undefined') return;
+    container.innerHTML = '';
+    paypal.Buttons({
+        createOrder: function(data, actions) {
+            return actions.order.create({
+                purchase_units: [{ amount: { value: cartTotal.toFixed(2) } }]
+            });
+        },
+        onApprove: function(data, actions) {
+            return actions.order.capture().then(function(details) {
+                alert('Transaction completed by ' + details.payer.name.given_name);
+                cart = [];
+                localStorage.removeItem('cart');
+                displayCart();
+            });
+        }
+    }).render('#paypal-button-container');
 }
 
 document.addEventListener('DOMContentLoaded', () => {


### PR DESCRIPTION
## Summary
- use embedded SVG images so ducks appear without network access
- integrate PayPal Buttons API into checkout page
- render PayPal button with cart total in JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841aba0711c832ebceb5a5219ee7ecc